### PR TITLE
ci: failure-handler가 cancelled 실행에서는 이슈를 만들지 않도록 수정

### DIFF
--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   handle-failure:
     name: Create failure issue
-    if: ${{ github.event.workflow_run.conclusion != 'success' }}
+    if: ${{ contains(fromJSON('["failure","timed_out","action_required"]'), github.event.workflow_run.conclusion) }}
     runs-on: ubuntu-latest
     steps:
       - name: Collect failed jobs


### PR DESCRIPTION
## 변경 내용
- `.github/workflows/failure-handler.yml`의 실행 조건을 수정했습니다.
- 기존: `success`가 아닌 모든 결론(`cancelled` 포함)에 대해 이슈 생성
- 변경: 아래 결론에서만 이슈 생성
  - `failure`
  - `timed_out`
  - `action_required`

## 문제 원인
- CI가 사용자 취소/동시성에 의해 `cancelled`로 종료되어도 failure-handler가 동작해 불필요한 장애 이슈가 생성되었습니다.

## 기대 효과
- 실제 실패에 대해서만 이슈가 생성됩니다.
- 수동 취소/자동 취소 케이스는 노이즈 없이 무시됩니다.

## 검증
- 워크플로우 조건식을 `contains(fromJSON(...), conclusion)` 형태로 제한해 GitHub Actions expression에서 평가되도록 반영했습니다.
- 변경 파일: `.github/workflows/failure-handler.yml`

Closes #1
