### PR TITLE
chore(helm): set portfolio replica count to 1

### DIFF
--- a/helm/portfolio/values.yaml
+++ b/helm/portfolio/values.yaml
@@ -1,9 +1,9 @@
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: ghcr.io/seung-ju-org/portfolio
   pullPolicy: IfNotPresent
-  tag: "main-6-46bd7df"
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -74,7 +74,7 @@ readinessProbe:
 
 autoscaling:
   enabled: false
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 75
 


### PR DESCRIPTION
## Summary
- set `replicaCount` from `2` to `1` in Helm values
- align `autoscaling.minReplicas` to `1` for consistency when autoscaling is enabled

## Why
- run a single replica by default for current workload/cost profile

## Changed File
- `helm/portfolio/values.yaml`
