### PR TITLE
chore(helm): enable autoscaling for portfolio

### DIFF
--- a/helm/portfolio/values.yaml
+++ b/helm/portfolio/values.yaml
@@ -73,7 +73,7 @@ readinessProbe:
   periodSeconds: 10
 
 autoscaling:
-  enabled: false
+  enabled: true
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 75


### PR DESCRIPTION
## Summary
- enable Helm autoscaling for portfolio deployment
- keep HPA bounds as `minReplicas: 1`, `maxReplicas: 5`
- keep CPU utilization target at `75%`

## Why
- allow replica scaling based on runtime load instead of fixed replica behavior

## Validation
- rendered Helm manifests and confirmed HPA is generated with expected values
  - `kind: HorizontalPodAutoscaler`
  - `minReplicas: 1`
  - `maxReplicas: 5`
  - `averageUtilization: 75`

## Changed File
- `helm/portfolio/values.yaml`
