### PR TITLE
ci: GHCR latest pull 오류 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,6 +88,7 @@ jobs:
           tags: |
             ${{ env.IMAGE_REPO }}:${{ steps.meta.outputs.image_tag }}
             ${{ env.IMAGE_REPO }}:ci-latest
+            ${{ env.IMAGE_REPO }}:latest
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 

--- a/helm/portfolio/values.yaml
+++ b/helm/portfolio/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/seung-ju-org/portfolio
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: "ci-latest"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## 변경 목적
배포 시 아래 에러로 이미지 Pull이 실패하던 문제를 수정합니다.

- `ghcr.io/seung-ju-org/portfolio:latest: not found`
- `ImagePullBackOff / ErrImagePull`

## 변경 내용
1. GitHub Actions 이미지 푸시 태그에 `latest` 추가
2. Helm 기본 태그를 `latest` -> `ci-latest`로 변경

## 수정 파일
- `.github/workflows/ci-cd.yml`
- `helm/portfolio/values.yaml`

## 기대 효과
- 클러스터가 `latest`를 요청해도 이미지가 존재
- 기본 배포 태그는 `ci-latest`로 안정적으로 동작
