### PR TITLE
security: harden input handling and add security scans

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,10 +9,6 @@ on:
       - "helm/portfolio/values.yaml"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  packages: write
-
 concurrency:
   group: portfolio-${{ github.ref }}
   cancel-in-progress: true
@@ -25,6 +21,8 @@ jobs:
   verify:
     name: Verify (lint/test/build)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,6 +54,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: verify
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,38 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "15 3 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/src/app/api/contact/route.test.ts
+++ b/src/app/api/contact/route.test.ts
@@ -78,4 +78,39 @@ describe("POST /api/contact", () => {
 
     expect(response.status).toBe(500);
   });
+
+  it("sanitizes html payload before composing email body", async () => {
+    const response = await POST(
+      buildRequest({
+        email: "user@example.com",
+        phone: "+82 10 0000 0000",
+        subject: "Hello <script>alert(1)</script>",
+        message: "<img src=x onerror=alert(1) />\nline2"
+      })
+    );
+
+    expect(response.status).toBe(200);
+
+    const transport = (nodemailer.createTransport as unknown as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(transport.sendMail).toHaveBeenCalledTimes(1);
+
+    const payload = transport.sendMail.mock.calls[0][0] as { html: string; subject: string; message?: string };
+    expect(payload.subject).toBe("Hello <script>alert(1)</script>");
+    expect(payload.html).not.toContain("<script>");
+    expect(payload.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(payload.html).toContain("&lt;img src=x onerror=alert(1) /&gt;<br />line2");
+  });
+
+  it("returns 400 for invalid email header injection payload", async () => {
+    const response = await POST(
+      buildRequest({
+        email: "attacker@example.com\r\nBcc:evil@example.com",
+        phone: "+82 10 0000 0000",
+        subject: "Hello",
+        message: "Test body"
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
 });

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -19,6 +19,28 @@ function isPlaceholderValue(value: string) {
   );
 }
 
+function sanitizeHeaderValue(value: string) {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function isValidEmail(value: string) {
+  if (value.length > 254) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function isReasonableLength(value: string, min: number, max: number) {
+  return value.length >= min && value.length <= max;
+}
+
 export async function POST(request: Request) {
   try {
     const body = (await request.json()) as {
@@ -28,12 +50,28 @@ export async function POST(request: Request) {
       message?: string;
     };
 
-    const email = body.email?.trim() ?? "";
-    const phone = body.phone?.trim() ?? "";
-    const subject = body.subject?.trim() ?? "";
-    const message = body.message?.trim() ?? "";
+    const email = sanitizeHeaderValue(body.email?.trim() ?? "");
+    const phone = sanitizeHeaderValue(body.phone?.trim() ?? "");
+    const subject = sanitizeHeaderValue(body.subject?.trim() ?? "");
+    const message = (body.message?.trim() ?? "").replace(/\r\n/g, "\n");
 
     if (!email || !phone || !subject || !message) {
+      return Response.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (!isValidEmail(email)) {
+      return Response.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (!isReasonableLength(phone, 7, 40)) {
+      return Response.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (!isReasonableLength(subject, 1, 200)) {
+      return Response.json({ error: "Invalid payload" }, { status: 400 });
+    }
+
+    if (!isReasonableLength(message, 1, 5000)) {
       return Response.json({ error: "Invalid payload" }, { status: 400 });
     }
 
@@ -82,6 +120,11 @@ export async function POST(request: Request) {
 
     await transporter.verify();
 
+    const safeEmail = escapeHtml(email);
+    const safePhone = escapeHtml(phone);
+    const safeSubject = escapeHtml(subject);
+    const safeMessage = escapeHtml(message).replace(/\n/g, "<br />");
+
     await transporter.sendMail({
       from,
       to,
@@ -89,11 +132,11 @@ export async function POST(request: Request) {
       subject,
       text: `Email: ${email}\nPhone: ${phone}\n\n${message}`,
       html: `
-        <p><strong>Email:</strong> ${email}</p>
-        <p><strong>Phone:</strong> ${phone}</p>
-        <p><strong>Subject:</strong> ${subject}</p>
+        <p><strong>Email:</strong> ${safeEmail}</p>
+        <p><strong>Phone:</strong> ${safePhone}</p>
+        <p><strong>Subject:</strong> ${safeSubject}</p>
         <hr />
-        <p>${message.replace(/\n/g, "<br />")}</p>
+        <p>${safeMessage}</p>
       `
     });
 


### PR DESCRIPTION
## Summary
- harden `/api/contact` input validation and sanitization
- prevent mail header injection via CRLF stripping
- escape HTML fields before mail body composition
- add CodeQL workflow for code scanning
- add dependency review workflow for PRs
- scope CI workflow permissions by job (least privilege)

## Details
### Contact API hardening
- validate email format and payload length bounds
- normalize/sanitize header values (`email`, `phone`, `subject`)
- HTML escape user-provided values in outgoing email HTML

### Security automation
- `.github/workflows/codeql.yml`
- `.github/workflows/dependency-review.yml`

### CI permission hardening
- `verify` job: `contents: read`
- `publish` job: `contents: write`, `packages: write`

## Verification
- `pnpm lint` passed
- `pnpm test -- --run src/app/api/contact/route.test.ts` passed
