### PR TITLE
Inject SMTP secrets into deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ Ingress host:
 
 - `portfolio.seung-ju.com`
 
+운영 메일 전송을 쓰려면 Helm `secretEnv`에 아래 값이 반드시 채워져 있어야 합니다.
+
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `SMTP_DOMAIN`
+- `SMTP_PROTOCOL`
+- `CONTACT_TO_EMAIL`
+- `CONTACT_FROM_EMAIL`
+
 ## 운영 메모
 
 - GitHub 원격: `git@github.com:seung-ju-org/portfolio.git`

--- a/helm/portfolio/templates/deployment.yaml
+++ b/helm/portfolio/templates/deployment.yaml
@@ -51,6 +51,46 @@ spec:
                 secretKeyRef:
                   name: {{ include "portfolio.fullname" . }}-env
                   key: REDIS_PASSWORD
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: SMTP_HOST
+            - name: SMTP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: SMTP_PORT
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: SMTP_USER
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: SMTP_PASS
+            - name: SMTP_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: SMTP_DOMAIN
+            - name: SMTP_PROTOCOL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: SMTP_PROTOCOL
+            - name: CONTACT_TO_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: CONTACT_TO_EMAIL
+            - name: CONTACT_FROM_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "portfolio.fullname" . }}-env
+                  key: CONTACT_FROM_EMAIL
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/helm/portfolio/templates/secret.yaml
+++ b/helm/portfolio/templates/secret.yaml
@@ -8,3 +8,11 @@ type: Opaque
 stringData:
   DATABASE_URL: {{ required "secretEnv.DATABASE_URL is required" .Values.secretEnv.DATABASE_URL | quote }}
   REDIS_PASSWORD: {{ .Values.secretEnv.REDIS_PASSWORD | quote }}
+  SMTP_HOST: {{ required "secretEnv.SMTP_HOST is required" .Values.secretEnv.SMTP_HOST | quote }}
+  SMTP_PORT: {{ required "secretEnv.SMTP_PORT is required" .Values.secretEnv.SMTP_PORT | quote }}
+  SMTP_USER: {{ required "secretEnv.SMTP_USER is required" .Values.secretEnv.SMTP_USER | quote }}
+  SMTP_PASS: {{ required "secretEnv.SMTP_PASS is required" .Values.secretEnv.SMTP_PASS | quote }}
+  SMTP_DOMAIN: {{ .Values.secretEnv.SMTP_DOMAIN | quote }}
+  SMTP_PROTOCOL: {{ .Values.secretEnv.SMTP_PROTOCOL | default "tls" | quote }}
+  CONTACT_TO_EMAIL: {{ .Values.secretEnv.CONTACT_TO_EMAIL | quote }}
+  CONTACT_FROM_EMAIL: {{ .Values.secretEnv.CONTACT_FROM_EMAIL | quote }}

--- a/helm/portfolio/values.yaml
+++ b/helm/portfolio/values.yaml
@@ -92,3 +92,11 @@ env:
 secretEnv:
   DATABASE_URL: "postgresql://<username>:<password>@postgresql-primary.postgresql.svc:5432/<database>?schema=portfolio"
   REDIS_PASSWORD: "<redis-password>"
+  SMTP_HOST: "smtp.example.com"
+  SMTP_PORT: "587"
+  SMTP_USER: "smtp-user@example.com"
+  SMTP_PASS: "<smtp-password>"
+  SMTP_DOMAIN: "portfolio.seung-ju.com"
+  SMTP_PROTOCOL: "tls"
+  CONTACT_TO_EMAIL: "seung-ju@seung-ju.com"
+  CONTACT_FROM_EMAIL: "no-reply@portfolio.seung-ju.com"


### PR DESCRIPTION
## Summary
- add SMTP and contact email settings to the Helm secret template
- inject those values into the application container environment
- document the required secretEnv entries for production mail delivery

## Testing
- helm lint helm/portfolio
- helm template portfolio ./helm/portfolio -f ./helm/portfolio/values.yaml